### PR TITLE
fix BoundingBox default value

### DIFF
--- a/src/math/BoundingBox.js
+++ b/src/math/BoundingBox.js
@@ -18,13 +18,13 @@ var BoundingBox = function (min, max) {
      * Minimum coords of bounding box
      * @type {qtek.math.Vector3}
      */
-    this.min = min || new Vector3(Infinity, Infinity, Infinity);
+    this.min = min || new Vector3(-Infinity, -Infinity, -Infinity);
 
     /**
      * Maximum coords of bounding box
      * @type {qtek.math.Vector3}
      */
-    this.max = max || new Vector3(-Infinity, -Infinity, -Infinity);
+    this.max = max || new Vector3(Infinity, Infinity, Infinity);
 };
 
 BoundingBox.prototype = {


### PR DESCRIPTION
BoundingBox的min和max值设反了

导致sceneViewBoundingBox的intersection结果不正确

例如ShadowMap中:
https://github.com/pissang/qtek/blob/master/src/prePass/ShadowMap.js#L769

计算出来的结果还是{ min : [Infinity, Infinity, Infinity], max : [-Infinity, -Infinity, -Infinity] }
