### PR TITLE
Update missing lib folder and libraries to CDN served files

### DIFF
--- a/example/IBL.html
+++ b/example/IBL.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script type="text/javascript" src="lib/require.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/alchemyao.html
+++ b/example/alchemyao.html
@@ -2,10 +2,10 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script type="text/javascript" src="lib/require.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
 
-        <script type="text/javascript" src="lib/stats.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/canvas/geometry.html
+++ b/example/canvas/geometry.html
@@ -7,7 +7,7 @@
     <canvas id="main"></canvas>
     <script type="text/javascript" src="http://s1.bdstatic.com/r/www/cache/ecom/esl/2-0-4/esl.js"></script>
 
-    <script type="text/javascript" src="../lib/stats.js"></script>
+    <script type="text/javascript" src="../https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     <script type="text/javascript" src="config.js"></script>
     <script type="text/javascript">
         require(['geometry']);

--- a/example/canvas/model.html
+++ b/example/canvas/model.html
@@ -7,7 +7,7 @@
     <canvas id="main"></canvas>
     <script type="text/javascript" src="http://s1.bdstatic.com/r/www/cache/ecom/esl/2-0-4/esl.js"></script>
 
-    <script type="text/javascript" src="../lib/stats.js"></script>
+    <script type="text/javascript" src="../https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     <script type="text/javascript" src="config.js"></script>
     <script type="text/javascript">
         require(['model']);

--- a/example/cubes.html
+++ b/example/cubes.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8">
         <script src="../dist/qtek.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;background-color:#20242B;">
         <canvas width="1200" height="640" id="main"></canvas>

--- a/example/curlnoise.html
+++ b/example/curlnoise.html
@@ -2,7 +2,7 @@
 <head>
     <title></title>
     <meta charset="utf-8">
-    <script type="text/javascript" src="lib/require.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
 </head>
 <body style="margin:0px;">
     <canvas id="main"></canvas>

--- a/example/deferred.html
+++ b/example/deferred.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8">
         <script src="../dist/qtek.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/deferred2.html
+++ b/example/deferred2.html
@@ -2,8 +2,8 @@
     <head>
         <meta charset="utf-8">
         <script src="../dist/qtek.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/deferred_shadow.html
+++ b/example/deferred_shadow.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="../dist/qtek.js"></script>
 
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/deferred_shadow3.html
+++ b/example/deferred_shadow3.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="../dist/qtek.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/deferred_sphere.html
+++ b/example/deferred_sphere.html
@@ -3,7 +3,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="../dist/qtek.js"></script>
-        <script src="lib/stats.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main" style="background: black;"></canvas>

--- a/example/deferred_tube.html
+++ b/example/deferred_tube.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8">
         <script src="../dist/qtek.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/dof.html
+++ b/example/dof.html
@@ -1,9 +1,9 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas width="1200" height="640" id="Main"></canvas>

--- a/example/gbuffer.html
+++ b/example/gbuffer.html
@@ -3,7 +3,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="../dist/qtek.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/glb.html
+++ b/example/glb.html
@@ -2,7 +2,7 @@
     <head>
         <title>GLTF2.0 Loader</title>
         <meta charset="utf-8">
-        <script type="text/javascript" src="lib/require.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
         <link rel="stylesheet" href="./css/common.css">
     </head>
     <body>

--- a/example/gltf2.html
+++ b/example/gltf2.html
@@ -2,7 +2,7 @@
 <head>
     <title>GLTF2.0 Loader</title>
     <meta charset="utf-8">
-    <script type="text/javascript" src="lib/require.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <link rel="stylesheet" href="./css/common.css">
 </head>
 <body>

--- a/example/lightgroup.html
+++ b/example/lightgroup.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8">
         <script src="../dist/qtek.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;background-color:#20242B;">
         <canvas width="1200" height="640" id="main"></canvas>

--- a/example/parallaxocclusionmap.html
+++ b/example/parallaxocclusionmap.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset='utf-8'>
         <script src='../dist/qtek.js'></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body>
         <canvas width='1200' height='640' id="main"></canvas>

--- a/example/pp_lensflare.html
+++ b/example/pp_lensflare.html
@@ -2,7 +2,7 @@
 <head>
     <title></title>
     <meta charset="utf-8">
-    <script type="text/javascript" src="lib/require.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
 </head>
 <body style="margin:0px">
     <canvas id="main"></canvas>

--- a/example/shadow_directional.html
+++ b/example/shadow_directional.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="../dist/qtek.js"></script>
 
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/ssr.html
+++ b/example/ssr.html
@@ -1,9 +1,9 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body style="margin:0px;">
         <style>

--- a/example/ssr2.html
+++ b/example/ssr2.html
@@ -1,9 +1,9 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body style="margin:0px;">
         <style>

--- a/example/ssr3.html
+++ b/example/ssr3.html
@@ -1,9 +1,9 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body style="margin:0px;">
         <style>

--- a/example/ssr4.html
+++ b/example/ssr4.html
@@ -1,9 +1,9 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body style="margin:0px;">
         <style>

--- a/example/standard_material.html
+++ b/example/standard_material.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script type="text/javascript" src="lib/require.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     </head>
     <body style="margin:0px;">
         <canvas id="main"></canvas>

--- a/example/tron.html
+++ b/example/tron.html
@@ -3,8 +3,8 @@
         <title>Tron Effect</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body>
         <style>

--- a/example/webvr.html
+++ b/example/webvr.html
@@ -4,8 +4,8 @@
         <meta charset="utf-8">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="viewport" content="width=device-width,initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/stats.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/r16/Stats.min.js"></script>
     </head>
     <body>
         <style>

--- a/example/webvr_tron.html
+++ b/example/webvr_tron.html
@@ -3,8 +3,8 @@
         <title>Tron Effect</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script type="text/javascript" src="lib/require.js"></script>
-        <script type="text/javascript" src="lib/dat.gui.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.5/dat.gui.min.js"></script>
     </head>
     <body>
         <style>


### PR DESCRIPTION
Related issue: https://github.com/pissang/qtek/issues/29

I've replaced the missing `lib/library` folder to libraries served from CDN's instead. This prevents shipping vendor code with the library and fixes the broken examples.